### PR TITLE
feat/mcapp-46-trade-delete

### DIFF
--- a/server/routes/trade-route.js
+++ b/server/routes/trade-route.js
@@ -25,6 +25,12 @@ tradeMocks.map((mock) => {
   })
 
   router.delete(`${mock.path}/:id`, (req, res) => {
+    const id = parseInt(req.params.id)
+    mock.data.splice(
+      mock.data.findIndex((s) => id === s.id),
+      1
+    )
+
     res.send({ success: true })
   })
 })

--- a/src/components/atoms/OverflowMenuIconComponent.tsx
+++ b/src/components/atoms/OverflowMenuIconComponent.tsx
@@ -1,0 +1,43 @@
+import { IonIcon } from '@ionic/react'
+import { ellipsisVertical } from 'ionicons/icons'
+import React, { FC } from 'react'
+import { useStore } from '../../hooks/use-store'
+
+export interface IOverflowMenuIcon {
+  show?: boolean
+  className?: string
+  icon?: string
+  onDelete?: () => void
+  onEdit?: () => void
+}
+
+export const OverflowMenuIcon: FC<IOverflowMenuIcon> = ({
+  show = true,
+  className = '',
+  icon = ellipsisVertical,
+  onDelete = () => {},
+  onEdit = () => {},
+}) => {
+  const { $ui } = useStore()
+
+  const showItemMenuPopup = async (e: React.MouseEvent<HTMLIonIconElement, MouseEvent>) => {
+    console.log('showItemMenuPopup')
+    const action = await $ui.showPopover(e.nativeEvent)
+    console.log('showItemMenuPopup action', action)
+
+    switch (action) {
+      case 'DELETE':
+        $ui.showAlert({
+          isOpen: true,
+          message: '게시글을 삭제하시겠어요?',
+          onSuccess: onDelete,
+        })
+        break
+      case 'EDIT':
+        onEdit()
+        break
+    }
+  }
+
+  return <IonIcon hidden={!show} className={className} icon={icon} onClick={showItemMenuPopup} />
+}

--- a/src/components/molecules/MypageProfileComponent.tsx
+++ b/src/components/molecules/MypageProfileComponent.tsx
@@ -1,7 +1,6 @@
-import { IonAvatar, IonButton } from '@ionic/react'
+import { IonAvatar, IonButton, useIonViewWillEnter } from '@ionic/react'
 import { useObserver } from 'mobx-react-lite'
-import { TaskGroup } from 'mobx-task'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useStore } from '../../hooks/use-store'
 import { route } from '../../route'
 import { Spinner } from '../atoms/SpinnerComponent'
@@ -11,20 +10,12 @@ import { TextXxl } from '../atoms/TextXxlComponent'
 export const MypageProfile: React.FC = () => {
   const { $user } = useStore()
 
-  // eslint-disable-next-line
-  const getCurrentUserTaskGroup = TaskGroup<any[], void>([$user.getCurrentUserId, $user.getUser])
-
-  useEffect(() => {
-    const getCurrentUser = async () => {
-      await $user.getCurrentUserId()
-      await $user.getUser($user.currentUserId!)
-    }
-
-    getCurrentUser()
-  }, [$user])
+  useIonViewWillEnter(() => {
+    $user.getCurrentUser()
+  })
 
   return useObserver(() =>
-    getCurrentUserTaskGroup.match({
+    $user.getCurrentUser.match({
       pending: () => {
         return (
           <div className='flex-center'>

--- a/src/components/molecules/TradeItemComponent.tsx
+++ b/src/components/molecules/TradeItemComponent.tsx
@@ -1,17 +1,19 @@
 import { IonIcon } from '@ionic/react'
-import { chatbox, cloud, ellipsisVertical } from 'ionicons/icons'
+import { chatbox, cloud } from 'ionicons/icons'
 import { useObserver } from 'mobx-react-lite'
 import React from 'react'
 import { useStore } from '../../hooks/use-store'
 import { ITrade } from '../../models/trade'
 import { route } from '../../route'
 import { TradeStore } from '../../stores/trade-store'
+import { OverflowMenuIcon } from '../atoms/OverflowMenuIconComponent'
 import { Profile } from '../atoms/ProfileComponent'
 import { TextBase } from '../atoms/TextBaseComponent'
 import { TextLg } from '../atoms/TextLgComponent'
 interface ITradeItem {
   store: TradeStore
   item: ITrade
+  searchKeyword: string
   isDetail?: boolean
 }
 
@@ -26,8 +28,17 @@ const StatusString = {
   FINISH: '거래완료',
 }
 
-export const TradeItem: React.FC<ITradeItem> = ({ store, item, isDetail = false }) => {
-  const { $ui, $user } = useStore()
+export const TradeItem: React.FC<ITradeItem> = ({ store, item, searchKeyword, isDetail = false }) => {
+  const { $user } = useStore()
+
+  const onDelete = async () => {
+    await store.deleteItem(item.id)
+    await store.getItems(searchKeyword)
+
+    if (isDetail) {
+      route.goBack()
+    }
+  }
 
   return useObserver(() => (
     <li className='py-4'>
@@ -66,33 +77,11 @@ export const TradeItem: React.FC<ITradeItem> = ({ store, item, isDetail = false 
         </div>
 
         <div className='flex justify-end w-4'>
-          {/* // TODO: extract component */}
-          <IonIcon
-            hidden={$user.currentUserId !== item.user.id}
+          <OverflowMenuIcon
             className='self-top'
-            icon={ellipsisVertical}
-            onClick={async (e) => {
-              const action = await $ui.showPopover(e.nativeEvent)
-              switch (action) {
-                case 'DELETE':
-                  $ui.showAlert({
-                    isOpen: true,
-                    message: '게시글을 삭제하시겠어요?',
-                    onSuccess: async () => {
-                      // TODO: 로더 추가
-                      await store.deleteItem(item.id)
-                      await store.getItems('') // TODO: keyword
-                      if (isDetail) {
-                        route.goBack()
-                      }
-                    },
-                  })
-                  break
-                case 'EDIT':
-                  break
-              }
-            }}
-          ></IonIcon>
+            show={$user.currentUserId === item.user.id}
+            onDelete={onDelete}
+          />
         </div>
       </div>
 

--- a/src/components/organisms/FeedListComponent.tsx
+++ b/src/components/organisms/FeedListComponent.tsx
@@ -1,5 +1,6 @@
 import { IonSpinner } from '@ionic/react'
 import { useObserver } from 'mobx-react-lite'
+import { TaskGroup } from 'mobx-task'
 import React, { useEffect } from 'react'
 import { useStore } from '../../hooks/use-store'
 import { FeedItem } from '../molecules/FeedItemComponent'
@@ -15,8 +16,11 @@ export const FeedList: React.FC<IFeedList> = () => {
     // eslint-disable-next-line
   }, [])
 
+  // eslint-disable-next-line
+  const taskGroup = TaskGroup<any[], void>([$feed.getFeeds, $feed.deleteFeed])
+
   return useObserver(() =>
-    $feed.getFeeds.match({
+    taskGroup.match({
       pending: () => (
         <div className='height-150 flex-center'>
           <IonSpinner color='tertiary' name='crescent' />
@@ -26,7 +30,7 @@ export const FeedList: React.FC<IFeedList> = () => {
         <>
           <ul className='pl-0 move-up'>
             {$feed.feeds.map((v, i) => (
-              <FeedItem key={i} feed={v} isDetail={false}></FeedItem>
+              <FeedItem key={i} feed={v}></FeedItem>
             ))}
           </ul>
           <ContentPopover></ContentPopover>

--- a/src/components/organisms/TradeListComponent.tsx
+++ b/src/components/organisms/TradeListComponent.tsx
@@ -1,5 +1,6 @@
 import { IonSpinner } from '@ionic/react'
 import { useObserver } from 'mobx-react-lite'
+import { TaskGroup } from 'mobx-task'
 import React, { useLayoutEffect } from 'react'
 import { TradeStore } from '../../stores/trade-store'
 import { TextBase } from '../atoms/TextBaseComponent'
@@ -21,8 +22,11 @@ export const TradeList: React.FC<ITradeList> = ({ store, searchKeyword }) => {
     store.getItems(searchKeyword)
   }, [searchKeyword, store])
 
+  // eslint-disable-next-line
+  const taskGroup = TaskGroup<any[], void>([store.getItems, store.deleteItem])
+
   return useObserver(() =>
-    store.getItems.match({
+    taskGroup.match({
       pending: () => (
         <div className='height-150 flex-center'>
           <IonSpinner color='tertiary' name='crescent' />
@@ -35,7 +39,7 @@ export const TradeList: React.FC<ITradeList> = ({ store, searchKeyword }) => {
           </div>
           <ul className='pl-0 move-up'>
             {store.items.map((item) => (
-              <TradeItem key={item.id} store={store} item={item} />
+              <TradeItem key={item.id} store={store} item={item} searchKeyword={searchKeyword} />
             ))}
           </ul>
           <ContentPopover></ContentPopover>

--- a/src/pages/FeedDetail.tsx
+++ b/src/pages/FeedDetail.tsx
@@ -8,6 +8,7 @@ import {
   useIonViewWillLeave,
 } from '@ionic/react'
 import { useObserver } from 'mobx-react-lite'
+import { TaskGroup } from 'mobx-task'
 import React, { useEffect } from 'react'
 import { StaticContext } from 'react-router'
 import { RouteComponentProps } from 'react-router-dom'
@@ -46,6 +47,9 @@ export const FeedDetail: React.FC<RouteComponentProps<{ id: string }, StaticCont
     $ui.setIsBottomTab(true)
   })
 
+  // eslint-disable-next-line
+  const taskGroup = TaskGroup<any[], void>([$feed.getFeed, $comment.deleteComment])
+
   return useObserver(() => (
     <IonPage>
       <IonHeader>
@@ -59,7 +63,7 @@ export const FeedDetail: React.FC<RouteComponentProps<{ id: string }, StaticCont
 
       <IonContent>
         <div className='px-container'>
-          {$feed.getFeed.match({
+          {taskGroup.match({
             pending: () => <Spinner isFull={true}></Spinner>,
             resolved: () => <FeedItem feed={$feed.feed} isDetail={true}></FeedItem>,
           })}

--- a/src/pages/Trade.tsx
+++ b/src/pages/Trade.tsx
@@ -26,6 +26,7 @@ export const Trade: React.FC = () => {
   const store = selectedSegment === segments.stuff ? $stuff : $talent
 
   const [searchMode, setSearchMode] = useState(false)
+  // TODO: move searchkeyword to trade-store for recent keyword list
   const [searchKeyword, setSearchKeyword] = useState(emptyKeyword)
   const onSearchSubmit = (e: CustomEvent<SearchbarChangeEventDetail>) => setSearchKeyword(e.detail.value!)
 

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -43,6 +43,12 @@ export class User {
   }
 
   @task
+  getCurrentUser = (async () => {
+    await this.getCurrentUserId()
+    this.getUser(this.currentUserId!)
+  }) as Task
+
+  @task
   getUser = (async (userId: number) => {
     await http.get<IUser>(`/users/${userId}`).then(
       action((data) => {


### PR DESCRIPTION
close #46

1. Trade list에서 overflow menu 중 Delete 동작 구현
   + 기존 코드를 OverflowMenuIcon component로 추출함


2. MypageProfile 이슈 수정
   * Issue: Mypage 진입해서 useEffect가 호출된 후,
     다른 곳으로 이동해서 $user.getUser() 호출하면 $user.user가 변경된다.
     다시 Mypage에 진입하면 useEffect가 호출되지 않기 때문에, 위에서 변경된 user값이 표시된다.
   * Fix: current user get 코드를 useEffect에서 useIonViewWillEnter로 옮김