### PR TITLE
feat: 물건재능 상세보기

### DIFF
--- a/src/RouterTab.tsx
+++ b/src/RouterTab.tsx
@@ -24,6 +24,7 @@ import { SignUpCommunityPage } from './pages/sign-up/SignUpCommunityPage'
 import { SignUpFormPage } from './pages/sign-up/SignUpFormPage'
 import { SignUpPage } from './pages/sign-up/SignUpPage'
 import { SignInPage } from './pages/SignInPage'
+import { StuffTalentDetailPage } from './pages/StuffTalentDetailPage'
 import { StuffTalentFormPage } from './pages/StuffTalentFormPage'
 import { StuffTalentPage } from './pages/StuffTalentPage'
 import './RouterTab.scss'
@@ -127,10 +128,10 @@ export const RouterTab: FC<IRouterTab> = ({ isShow, chatUnreadCount }) => {
             <GuardRoute path='/feed/:id' component={FeedDetailPage} exact />
             <GuardRoute path='/feed-write' component={FeedWritePage} exact />
             <GuardRoute path='/stuff' component={StuffTalentPage} exact />
-            {/* <GuardRoute path='/stuff/:id' component={StuffTalentDetailPage} exact /> */}
+            <GuardRoute path='/stuff/:id' component={StuffTalentDetailPage} exact />
             <GuardRoute path='/stuff-form' component={StuffTalentFormPage} exact />
             <GuardRoute path='/talent' component={StuffTalentPage} exact />
-            {/* <GuardRoute path='/talent/:id' component={StuffTalentDetailPage} exact /> */}
+            <GuardRoute path='/talent/:id' component={StuffTalentDetailPage} exact />
             <GuardRoute path='/talent-form' component={StuffTalentFormPage} exact />
             <GuardRoute path='/club' component={ClubPage} exact />
             <GuardRoute path='/club-form' component={ClubFormPage} exact />

--- a/src/components/molecules/StuffTalentDetailContentsComponent.tsx
+++ b/src/components/molecules/StuffTalentDetailContentsComponent.tsx
@@ -1,0 +1,92 @@
+import { FC } from 'react'
+import { IStuffTalent, StuffTalentType } from '../../models/stufftalent.d'
+import { route } from '../../services/route-service'
+import { timeDiff } from '../../utils/datetime-util'
+import { Description } from '../atoms/DescriptionComponent'
+import { Pad } from '../atoms/PadComponent'
+import { Profile } from '../atoms/ProfileComponent'
+import { TextBase } from '../atoms/TextBaseComponent'
+import { TextLg } from '../atoms/TextLgComponent'
+import { TextSm } from '../atoms/TextSmComponent'
+import { XDivider } from '../atoms/XDividerComponent'
+import { ImageSlider } from './ImageSliderComponent'
+import { MorePopoverButton } from './MorePopoverButtonComponent'
+
+export interface IStuffTalentDetailContents {
+  item: IStuffTalent
+  loginUserId: number
+  onEdit: (id: number) => void
+  onDelete: (id: number) => void
+}
+
+export const StuffTalentDetailContents: FC<IStuffTalentDetailContents> = ({
+  item,
+  loginUserId,
+  onEdit,
+  onDelete,
+}) => {
+  return (
+    <div>
+      <ImageSlider urls={item.imageUrls}></ImageSlider>
+      <div className='px-container pt-2'>
+        <div className='flex items-center'>
+          <TextLg className='mr-2'>{item.type}</TextLg>
+          <TextLg className='text-bold'>{item.title}</TextLg>
+        </div>
+
+        <div className='flex items-center mt-1'>
+          <TextSm>{item.isExchangeable && '교환 가능'}</TextSm>
+          <TextSm>{item.isNegotiable && '가격제안 가능'}</TextSm>
+          <TextSm>{item.category.name}</TextSm>
+        </div>
+
+        <div
+          className='flex items-center mt-1'
+          hidden={[StuffTalentType.SHARE, StuffTalentType.WANT].includes(item.type)}
+        >
+          <TextBase>{item.type === StuffTalentType.SELL ? item.price + '원' : item.exchangeText}</TextBase>
+        </div>
+
+        <XDivider className='mt-4 mb-6'></XDivider>
+
+        <div className='flex-between-center'>
+          <div
+            className='flex items-center'
+            onClick={() => {
+              route.profileDetail(item.user.id)
+            }}
+          >
+            <Profile url={item.user.profileUrl} className='mr-2 w-10 h-10'></Profile>
+            <div className='flex-col'>
+              <TextBase>{item.user.nickname}</TextBase>
+
+              <TextSm className='gray'>
+                {/* TODO community name 표시부분 공통화하기 */}
+                {item.user.communities.map((community) => community.name).join('/')} /{' '}
+                {timeDiff(item.createdAt)}
+              </TextSm>
+            </div>
+          </div>
+
+          {loginUserId === item.user.id && (
+            <MorePopoverButton
+              items={[
+                {
+                  label: '수정',
+                  onClick: () => onEdit(item.id),
+                },
+                {
+                  label: '삭제',
+                  onClick: () => onDelete(item.id),
+                },
+              ]}
+            />
+          )}
+        </div>
+
+        <Pad className='mt-4' />
+        <Description>{item.content}</Description>
+      </div>
+    </div>
+  )
+}

--- a/src/components/molecules/StuffTalentDetailContentsComponent.tsx
+++ b/src/components/molecules/StuffTalentDetailContentsComponent.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useStore } from '../../hooks/use-store'
 import { IStuffTalent, StuffTalentType } from '../../models/stufftalent.d'
 import { route } from '../../services/route-service'
 import { timeDiff } from '../../utils/datetime-util'
@@ -25,6 +26,8 @@ export const StuffTalentDetailContents: FC<IStuffTalentDetailContents> = ({
   onEdit,
   onDelete,
 }) => {
+  const { $ui } = useStore()
+
   return (
     <div>
       <ImageSlider urls={item.imageUrls}></ImageSlider>
@@ -77,7 +80,13 @@ export const StuffTalentDetailContents: FC<IStuffTalentDetailContents> = ({
                 },
                 {
                   label: '삭제',
-                  onClick: () => onDelete(item.id),
+                  onClick: () => {
+                    $ui.showAlert({
+                      isOpen: true,
+                      message: '게시글을 삭제하시겠어요?',
+                      onSuccess: () => onDelete(item.id),
+                    })
+                  },
                 },
               ]}
             />

--- a/src/components/molecules/StuffTalentItemComponent.tsx
+++ b/src/components/molecules/StuffTalentItemComponent.tsx
@@ -1,7 +1,7 @@
 import { IonIcon } from '@ionic/react'
 import { chatbox, cloud } from 'ionicons/icons'
-import { getLabel, statusLabels, typeLabels } from '../../models/stufftalent'
-import { IStuffTalent, StuffTalentPathName as Path } from '../../models/stufftalent.d'
+import { getLabel, routeFunc, statusLabels, typeLabels } from '../../models/stufftalent'
+import { IStuffTalent, StuffTalentPageKey } from '../../models/stufftalent.d'
 import { route } from '../../services/route-service'
 import { timeDiff } from '../../utils/datetime-util'
 import { OverflowMenuIcon } from '../atoms/OverflowMenuIconComponent'
@@ -11,7 +11,7 @@ import { TextLg } from '../atoms/TextLgComponent'
 
 interface IStuffTalentIItem {
   loginUserId: number
-  path: Path
+  pageKey: StuffTalentPageKey
   item: IStuffTalent
   onEdit: (id: number) => void
   onDelete: (id: number) => void
@@ -19,13 +19,12 @@ interface IStuffTalentIItem {
 
 export const StuffTalentItem: React.FC<IStuffTalentIItem> = ({
   loginUserId,
-  path,
+  pageKey,
   item,
   onEdit,
   onDelete,
 }) => {
-  const routeDetail =
-    path === Path.STUFF ? (id: number) => route.stuffDetail(id) : (id: number) => route.talentDetail(id)
+  const { routeDetail } = routeFunc[pageKey]
 
   return (
     <li>

--- a/src/components/organisms/StuffTalentListComponent.tsx
+++ b/src/components/organisms/StuffTalentListComponent.tsx
@@ -27,7 +27,7 @@ export const StuffTalentList: React.FC<IStuffTalentList> = ({ store, search, fil
     await store.getUpdateForm(id)
 
     // TODO 개선 필요
-    store.pathName === StuffTalentPathName.STUFF ? route.stuffForm() : route.talentForm()
+    store.predefined.pathName === StuffTalentPathName.STUFF ? route.stuffForm() : route.talentForm()
   }
 
   const onDeleteItem = async (id: number) => {
@@ -55,7 +55,7 @@ export const StuffTalentList: React.FC<IStuffTalentList> = ({ store, search, fil
               <StuffTalentItem
                 key={item.id}
                 loginUserId={$auth.user.id}
-                path={store.pathName}
+                path={store.predefined.pathName}
                 item={item}
                 onEdit={onEditItem}
                 onDelete={onDeleteItem}

--- a/src/components/organisms/StuffTalentListComponent.tsx
+++ b/src/components/organisms/StuffTalentListComponent.tsx
@@ -3,8 +3,8 @@ import { useObserver } from 'mobx-react-lite'
 import { TaskGroup } from 'mobx-task'
 import { useEffect } from 'react'
 import { useStore } from '../../hooks/use-store'
-import { IStuffTalentFilter, StuffTalentPathName } from '../../models/stufftalent.d'
-import { route } from '../../services/route-service'
+import { routeFunc } from '../../models/stufftalent'
+import { IStuffTalentFilter } from '../../models/stufftalent.d'
 import { StuffTalentStore } from '../../stores/stufftalent-store'
 import { TextBase } from '../atoms/TextBaseComponent'
 import { StuffTalentItem } from '../molecules/StuffTalentItemComponent'
@@ -23,11 +23,11 @@ export const StuffTalentList: React.FC<IStuffTalentList> = ({ store, search, fil
     store.getItems(search, filter)
   }, [store, search, filter])
 
+  const { routeForm } = routeFunc[store.predefined.pageKey]
+
   const onEditItem = async (id: number) => {
     await store.getUpdateForm(id)
-
-    // TODO 개선 필요
-    store.predefined.pathName === StuffTalentPathName.STUFF ? route.stuffForm() : route.talentForm()
+    routeForm()
   }
 
   const onDeleteItem = async (id: number) => {
@@ -55,7 +55,7 @@ export const StuffTalentList: React.FC<IStuffTalentList> = ({ store, search, fil
               <StuffTalentItem
                 key={item.id}
                 loginUserId={$auth.user.id}
-                path={store.predefined.pathName}
+                pageKey={store.predefined.pageKey}
                 item={item}
                 onEdit={onEditItem}
                 onDelete={onDeleteItem}

--- a/src/models/stufftalent.d.ts
+++ b/src/models/stufftalent.d.ts
@@ -1,7 +1,7 @@
 import { ImageUploadItem } from '../components/molecules/ImageUploaderComponent'
 import { IStuffTalentDto } from '../stores/stufftalent-store.d'
 
-export enum StuffTalentPathName {
+export enum StuffTalentPageKey {
   STUFF = 'STUFF',
   TALENT = 'TALENT',
 }
@@ -22,6 +22,7 @@ export enum StuffTalentStatus {
 export interface IStuffTalent extends IStuffTalentDto {
   likeCount: number
   imageUrls: string[]
+  chatroomId: number
 }
 
 export interface IStuffTalentFilter {

--- a/src/models/stufftalent.ts
+++ b/src/models/stufftalent.ts
@@ -1,15 +1,18 @@
-import { IStuffTalentDto } from '../stores/stufftalent-store.d'
-import { IStuffTalent, StuffTalentPathName, StuffTalentStatus, StuffTalentType } from './stufftalent.d'
+import { IStuffTalentPredefined } from '../stores/stufftalent-store'
+import { IStuffTalentDto, IStuffTalentLikeUserDto } from '../stores/stufftalent-store.d'
+import { getKeyValue } from '../utils/type-util'
+import { IStuffTalent, StuffTalentStatus, StuffTalentType } from './stufftalent.d'
 
 export interface StuffTalent extends IStuffTalent {}
 
 export class StuffTalent {
-  static of(payload: IStuffTalentDto, pathname: StuffTalentPathName) {
+  static of(payload: IStuffTalentDto, predefined: IStuffTalentPredefined) {
     return Object.assign(new StuffTalent(), {
       ...payload,
-      likeCount: (pathname === StuffTalentPathName.STUFF ? payload.stuffUsers : payload.talentUsers).filter(
-        (s) => s.isLike && s.isUse
-      ).length,
+      likeCount: (getKeyValue(
+        payload,
+        predefined.likeUsersProperty as keyof IStuffTalentDto
+      ) as IStuffTalentLikeUserDto[]).filter((likeUsers) => likeUsers.isLike && likeUsers.isUse).length,
       imageUrls: payload.atchFiles.map((v) => v.url),
       // chatroomId: payload.chatroom.id, // TODO
     })

--- a/src/models/stufftalent.ts
+++ b/src/models/stufftalent.ts
@@ -1,7 +1,9 @@
+import _ from 'lodash'
+import { route } from '../services/route-service'
 import { IStuffTalentPredefined } from '../stores/stufftalent-store'
 import { IStuffTalentDto, IStuffTalentLikeUserDto } from '../stores/stufftalent-store.d'
 import { getKeyValue } from '../utils/type-util'
-import { IStuffTalent, StuffTalentStatus, StuffTalentType } from './stufftalent.d'
+import { IStuffTalent, StuffTalentPageKey, StuffTalentStatus, StuffTalentType } from './stufftalent.d'
 
 export interface StuffTalent extends IStuffTalent {}
 
@@ -11,10 +13,10 @@ export class StuffTalent {
       ...payload,
       likeCount: (getKeyValue(
         payload,
-        predefined.likeUsersProperty as keyof IStuffTalentDto
+        predefined.stuffTalentUsersProperty as keyof IStuffTalentDto
       ) as IStuffTalentLikeUserDto[]).filter((likeUsers) => likeUsers.isLike && likeUsers.isUse).length,
       imageUrls: payload.atchFiles.map((v) => v.url),
-      // chatroomId: payload.chatroom.id, // TODO
+      chatroomId: payload.chatroom?.id, //TODO 서버 response에서 chatroom 정보 넘기도록 수정 후 ? 제거
     })
   }
 }
@@ -39,3 +41,29 @@ export const statusLabels: ILabel[] = [
   { value: StuffTalentStatus.RESERVED, label: '예약중' },
   { value: StuffTalentStatus.FINISH, label: '거래완료' },
 ]
+
+export const getPageKey = (path: string) => {
+  const upperPath = path.toUpperCase()
+  return _.find(StuffTalentPageKey, (pageKey) => upperPath.includes(pageKey))!
+}
+
+interface IRouteFunc {
+  [index: string]: {
+    routeList: () => void
+    routeForm: () => void
+    routeDetail: (id: number) => void
+  }
+}
+
+export const routeFunc: IRouteFunc = {
+  [StuffTalentPageKey.STUFF]: {
+    routeList: () => route.stuff(),
+    routeForm: () => route.stuffForm(),
+    routeDetail: (id) => route.stuffDetail(id),
+  },
+  [StuffTalentPageKey.TALENT]: {
+    routeList: () => route.talent(),
+    routeForm: () => route.talentForm(),
+    routeDetail: (id) => route.talentDetail(id),
+  },
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ import { HomeTitle } from '../components/molecules/HomeTitleComponent'
 import { StuffTalentItem } from '../components/molecules/StuffTalentItemComponent'
 import { ClubPopularSlider } from '../components/organisms/ClubPopularSliderComponent'
 import { useStore } from '../hooks/use-store'
-import { StuffTalentPathName } from '../models/stufftalent.d'
+import { StuffTalentPageKey } from '../models/stufftalent.d'
 import { route } from '../services/route-service'
 
 export const HomePage: React.FC = () => {
@@ -65,7 +65,7 @@ export const HomePage: React.FC = () => {
             <StuffTalentItem
               key={item.id}
               loginUserId={$auth.user.id}
-              path={StuffTalentPathName.STUFF}
+              pageKey={StuffTalentPageKey.STUFF}
               item={item}
               onEdit={() => {}}
               onDelete={() => {}}
@@ -76,7 +76,7 @@ export const HomePage: React.FC = () => {
             <StuffTalentItem
               key={item.id}
               loginUserId={$auth.user.id}
-              path={StuffTalentPathName.STUFF}
+              pageKey={StuffTalentPageKey.STUFF}
               item={item}
               onEdit={() => {}}
               onDelete={() => {}}

--- a/src/pages/StuffTalentDetailPage.tsx
+++ b/src/pages/StuffTalentDetailPage.tsx
@@ -1,0 +1,110 @@
+import { IonContent, IonPage, useIonViewWillEnter } from '@ionic/react'
+import { useObserver } from 'mobx-react-lite'
+import React, { useEffect } from 'react'
+import { StaticContext } from 'react-router'
+import { RouteComponentProps, useLocation } from 'react-router-dom'
+import { Icon } from '../components/atoms/IconComponent'
+import { Pad } from '../components/atoms/PadComponent'
+import { Spinner } from '../components/atoms/SpinnerComponent'
+import { SubmitButton } from '../components/atoms/SubmitButtonComponent'
+import { TextSm } from '../components/atoms/TextSmComponent'
+import { BackFloatingButton } from '../components/molecules/BackFloatingButtonComponent'
+import { StuffTalentDetailContents } from '../components/molecules/StuffTalentDetailContentsComponent'
+import { Footer } from '../components/organisms/FooterComponent'
+import { useStore } from '../hooks/use-store'
+import { StuffTalentPathName } from '../models/stufftalent.d'
+import { route } from '../services/route-service'
+
+export const StuffTalentDetailPage: React.FC<RouteComponentProps<{ id: string }, StaticContext>> = ({
+  match,
+}) => {
+  const id = parseInt(match.params.id)
+  const { pathname } = useLocation()
+
+  const { $ui, $stuff, $talent, $auth } = useStore()
+  const store = pathname.startsWith('/stuff/') ? $stuff : $talent
+
+  useIonViewWillEnter(() => {
+    // TODO: statusbar 투명 체크
+    $ui.setIsBottomTab(false)
+  })
+
+  useEffect(
+    () => {
+      store.getItem(id)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  // TODO ERROR: 수정화면 진입 시, getUpdateForm 안에서 getItem이 호출되는데
+  // 이 때문에 unmount된 detail component가 rerender되면서 에러 발생함.
+  const onEdit = async (id: number) => {
+    await store.getUpdateForm(id)
+    pathname === StuffTalentPathName.STUFF ? route.stuffForm() : route.talentForm()
+  }
+
+  const onDelete = async (id: number) => {
+    await store.deleteItem(id)
+    route.goBack()
+  }
+
+  return useObserver(() =>
+    store.getItem.state === 'pending' ? (
+      <Spinner isFull={true} />
+    ) : (
+      <IonPage>
+        <IonContent>
+          <BackFloatingButton></BackFloatingButton>
+          {/* TODO dont pass store */}
+          <StuffTalentDetailContents
+            item={store.item}
+            loginUserId={$auth.user.id}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+          <Pad className='pb-extra-space'></Pad>
+        </IonContent>
+
+        <Footer>
+          <div className='flex-between-center mx-4'>
+            <div
+              className='flex-col items-center'
+              onClick={async () => {
+                await store.toggleLike(id, !store.item.isLike)
+              }}
+            >
+              <Icon name={store.item.isLike ? 'heart-solid' : 'heart'} />
+              <TextSm>{store.item.likeCount}</TextSm>
+            </div>
+
+            <div className='w-full ml-4'>
+              {/* {!store.item?.isMember ? ( // TODO 조건 : chatroomid 있는지 여부
+            <SpinnerWrapper
+              task={store.createChat}
+              Submit={() => (
+                <SubmitButton
+                  text='채팅으로 거래하기'
+                  onClick={() => {
+                    // 새채팅 생성하고 해당 채팅룸으로 이동하기
+                    // $club.joinClub({ clubId: $club.club.id, userId: $auth.user.id })
+                    // TODO: 테스트후 주석 제거
+                    // route.chatRoom($club.club.chatroomId)
+                  }}
+                ></SubmitButton>
+              )}
+            ></SpinnerWrapper>
+          ) : ( */}
+              <SubmitButton
+                text='채팅으로 거래하기'
+                // TODO: set chatRoom Id
+                onClick={() => route.chatRoom(1)}
+              ></SubmitButton>
+              {/* )} */}
+            </div>
+          </div>
+        </Footer>
+      </IonPage>
+    )
+  )
+}

--- a/src/pages/StuffTalentFormPage.tsx
+++ b/src/pages/StuffTalentFormPage.tsx
@@ -14,22 +14,22 @@ import { CategorySelector } from '../components/molecules/CategorySelectorCompon
 import { IImageUploaderRef, ImageUploader } from '../components/molecules/ImageUploaderComponent'
 import { Header } from '../components/organisms/HeaderComponent'
 import { useStore } from '../hooks/use-store'
-import { typeLabels } from '../models/stufftalent'
-import { IStuffTalentForm, StuffTalentType } from '../models/stufftalent.d'
-import { route } from '../services/route-service'
+import { getPageKey, routeFunc, typeLabels } from '../models/stufftalent'
+import { IStuffTalentForm, StuffTalentPageKey, StuffTalentType } from '../models/stufftalent.d'
 import { executeWithError } from '../utils/http-helper-util'
 
 export const StuffTalentFormPage: React.FC = () => {
   const { $ui, $stuff, $talent, $community } = useStore()
 
-  const { pathname } = useLocation()
-  // TODO fix here
-  const store = pathname === '/stuff-form' ? $stuff : $talent
-  const title = pathname === '/stuff-form' ? '물건' : '재능'
-  const routeList = () => (pathname === '/stuff-form' ? route.stuff() : route.talent())
+  const pageData = {
+    [StuffTalentPageKey.STUFF]: { store: $stuff, title: '물건' },
+    [StuffTalentPageKey.TALENT]: { store: $talent, title: '재능' },
+  }
+
+  const { store, title } = pageData[getPageKey(useLocation().pathname)]
+  const { routeList } = routeFunc[store.predefined.pageKey]
 
   const isUpdate = !!store.updateForm.id
-  console.log('form enter', isUpdate, store.updateForm, 'store.form', store.form)
   const form = Object.assign({}, isUpdate ? { ...store.updateForm } : { ...store.form })
 
   const {
@@ -93,7 +93,6 @@ export const StuffTalentFormPage: React.FC = () => {
   })
 
   useIonViewWillLeave(() => {
-    console.log('useIonViewWillLeaveuseIonViewWillLeaveuseIonViewWillLeaveuseIonViewWillLeave')
     isUpdate ? store.resetUpdateForm() : store.resetForm()
 
     // TODO 임시저장 루틴을 통일하자 - 물건, 재능, 이야기 등

--- a/src/pages/StuffTalentFormPage.tsx
+++ b/src/pages/StuffTalentFormPage.tsx
@@ -29,7 +29,8 @@ export const StuffTalentFormPage: React.FC = () => {
   const routeList = () => (pathname === '/stuff-form' ? route.stuff() : route.talent())
 
   const isUpdate = !!store.updateForm.id
-  const form = isUpdate ? store.updateForm : store.form
+  console.log('form enter', isUpdate, store.updateForm, 'store.form', store.form)
+  const form = Object.assign({}, isUpdate ? { ...store.updateForm } : { ...store.form })
 
   const {
     formState: { isValid, dirtyFields },
@@ -92,6 +93,7 @@ export const StuffTalentFormPage: React.FC = () => {
   })
 
   useIonViewWillLeave(() => {
+    console.log('useIonViewWillLeaveuseIonViewWillLeaveuseIonViewWillLeaveuseIonViewWillLeave')
     isUpdate ? store.resetUpdateForm() : store.resetForm()
 
     // TODO 임시저장 루틴을 통일하자 - 물건, 재능, 이야기 등
@@ -111,12 +113,12 @@ export const StuffTalentFormPage: React.FC = () => {
       const [exchangeText, price] = getValues(['exchangeText', 'price'])
 
       // 불필요한 setValue 호출을 막기 위해 현재 빈 값인 필드는 그냥 둔다.
-      if (watchType === StuffTalentType.SHARE || watchType === StuffTalentType.WANT) {
+      if ([StuffTalentType.SHARE, StuffTalentType.WANT].includes(watchType)) {
         !!exchangeText && setValueCustom('exchangeText', undefined)
         !!price && setValueCustom('price', undefined)
-      } else if (watchType === StuffTalentType.SELL) {
+      } else if (StuffTalentType.SELL === watchType) {
         !!exchangeText && setValueCustom('exchangeText', undefined)
-      } else if (watchType === StuffTalentType.EXCHANGE) {
+      } else if (StuffTalentType.EXCHANGE === watchType) {
         !!price && setValueCustom('price', undefined)
       }
     },

--- a/src/pages/StuffTalentPage.tsx
+++ b/src/pages/StuffTalentPage.tsx
@@ -17,9 +17,8 @@ import { FilterBar } from '../components/molecules/FilterBarComponent'
 import { FilterPopup } from '../components/molecules/FilterPopupComponent'
 import { StuffTalentList } from '../components/organisms/StuffTalentListComponent'
 import { useStore } from '../hooks/use-store'
-import { typeLabels } from '../models/stufftalent'
-import { IStuffTalentFilter, StuffTalentStatus } from '../models/stufftalent.d'
-import { route } from '../services/route-service'
+import { getPageKey, routeFunc, typeLabels } from '../models/stufftalent'
+import { IStuffTalentFilter, StuffTalentPageKey, StuffTalentStatus } from '../models/stufftalent.d'
 
 interface SearchbarChangeEventDetail {
   value: string | undefined
@@ -32,13 +31,14 @@ const initialSearch = ''
 
 export const StuffTalentPage: React.FC = () => {
   const { $stuff, $talent, $ui, $community } = useStore()
-  const { pathname } = useLocation()
 
-  // TODO 경로명 하드코딩하지 않기
-  const store = pathname === '/stuff' ? $stuff : $talent
-  const routeForm = () => {
-    pathname === '/stuff' ? route.stuffForm() : route.talentForm()
+  const pageData = {
+    [StuffTalentPageKey.STUFF]: { store: $stuff },
+    [StuffTalentPageKey.TALENT]: { store: $talent },
   }
+
+  const { store } = pageData[getPageKey(useLocation().pathname)]
+  const { routeForm } = routeFunc[store.predefined.pageKey]
 
   const [searchMode, setSearchMode] = useState(false)
   const [search, setSearch] = useState(initialSearch)

--- a/src/stores/feed-store.ts
+++ b/src/stores/feed-store.ts
@@ -177,14 +177,17 @@ export class FeedStore {
 
   @action
   setFeedLike(id: number, isLike: boolean) {
-    let found = this.feeds.find((v) => v.id === id)
+    // TODO store의 현재 items와 item 데이터를 둘다 갱신해야 돼서 이렇게 구현했는데, 보기에 개운하지 않음.
+    const found = this.feed.id === id ? this.feed : this.feeds.find((v) => v.id === id)
 
     if (found) {
       const likeCount = isLike ? found.likeCount + 1 : found.likeCount - 1
-      // TODO: feeds의 일부 프로퍼티가 변경되어도 리렌더가 되지 않는다. 원인 파악 필요
+
       this.feeds = this.feeds.map((v) => {
-        return v.id === id ? { ...found!, isLike, likeCount } : v
+        return v.id === id ? { ...found!, isLike: isLike, likeCount: likeCount } : v
       })
+
+      this.feed = this.feed.id === id ? { ...this.feed, isLike: isLike, likeCount: likeCount } : this.feed
     }
   }
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,5 +1,5 @@
 import { configure } from 'mobx'
-import { StuffTalentPathName as PathName } from './../models/stufftalent.d'
+import { StuffTalentPageKey as PageKey } from './../models/stufftalent.d'
 import { AuthStore } from './auth-store'
 import { ChatStore } from './chat-store'
 import { ClubStore } from './club-store'
@@ -39,8 +39,8 @@ export class RootStore {
     this.$comment = new CommentStore()
     this.$ui = new UiStore()
     this.$user = new UserStore()
-    this.$stuff = new StuffTalentStore(PathName.STUFF)
-    this.$talent = new StuffTalentStore(PathName.TALENT)
+    this.$stuff = new StuffTalentStore(PageKey.STUFF)
+    this.$talent = new StuffTalentStore(PageKey.TALENT)
     this.$chat = new ChatStore()
     this.$club = new ClubStore(this)
     this.$segment = new SegmentStore()

--- a/src/stores/stufftalent-store.d.ts
+++ b/src/stores/stufftalent-store.d.ts
@@ -1,7 +1,6 @@
 import { IUser } from '../models/user.d'
 import {
   IStuffTalentForm,
-  StuffTalentPathName as PathName,
   StuffTalentStatus as Status,
   StuffTalentType as Type,
 } from './../models/stufftalent.d'
@@ -56,5 +55,3 @@ export interface IStuffTalentCommunityDto {
   id: number
   name: string
 }
-
-export type StuffTalentPath = { [name in PathName]: string }

--- a/src/stores/stufftalent-store.d.ts
+++ b/src/stores/stufftalent-store.d.ts
@@ -15,6 +15,7 @@ interface IStuffTalentDtoBase {
   status: Status
   category: IStuffTalentCategoryDto
   community: IStuffTalentCommunityDto
+  chatroom: IStuffTalentChatroomDto
   user: IUser
   title: string
   content: string
@@ -26,6 +27,22 @@ interface IStuffTalentDtoBase {
   isPublic: boolean
   createdAt: string
   atchFiles: IFileDto[]
+  isUse: boolean
+}
+
+interface IStuffTalentInsertReqDto {
+  id: number
+  type: Type
+  status: Status
+  categoryId: number
+  communityId: number
+  title: string
+  content: string
+  price: number
+  exchangeText: string
+  isExchangeable: boolean
+  isNegotiable: boolean
+  isPublic: boolean
   isUse: boolean
 }
 
@@ -54,4 +71,14 @@ export interface IStuffTalentCategoryDto {
 export interface IStuffTalentCommunityDto {
   id: number
   name: string
+}
+
+export interface IStuffTalentChatroomDto {
+  id: number
+}
+
+export interface ICreateChatDto {
+  stuffId?: number
+  talentId?: number
+  userId: number
 }

--- a/src/stores/stufftalent-store.ts
+++ b/src/stores/stufftalent-store.ts
@@ -7,7 +7,7 @@ import {
   IStuffTalent,
   IStuffTalentFilter,
   IStuffTalentForm,
-  StuffTalentPathName as PathName,
+  StuffTalentPageKey as PageKey,
   StuffTalentStatus,
   StuffTalentType,
 } from '../models/stufftalent.d'
@@ -15,10 +15,12 @@ import { api } from '../services/api-service'
 import { urlToFile } from '../utils/image-util'
 import { getKeyValue } from '../utils/type-util'
 import {
+  ICreateChatDto,
   InsertStuffTalentTask,
   IStuffsTalentsDto,
   IStuffTalentCategoryDto,
   IStuffTalentDto,
+  IStuffTalentInsertReqDto,
 } from './stufftalent-store.d'
 import { TaskBy, TaskBy2 } from './task'
 
@@ -36,11 +38,12 @@ const initState = {
 }
 
 export interface IStuffTalentPredefined {
-  pathName: PathName
+  pageKey: PageKey
   baseApi: string
   toggleLikeApi: string
-  toggleLikeIdProperty: string
-  likeUsersProperty: string
+  createChatApi: string
+  stuffTalentIdProperty: string
+  stuffTalentUsersProperty: string
   getItemsProperty: string
   insertItemReqDto: string
 }
@@ -49,20 +52,22 @@ const apiVer = 'v1'
 
 const predefined: IStuffTalentPredefined[] = [
   {
-    pathName: PathName.STUFF,
+    pageKey: PageKey.STUFF,
     baseApi: `/${apiVer}/stuffs`,
     toggleLikeApi: `/${apiVer}/stuffs-users/likes`,
-    toggleLikeIdProperty: 'stuffId',
-    likeUsersProperty: 'stuffUsers',
+    createChatApi: `/${apiVer}/stuffs-users/chatrooms`,
+    stuffTalentIdProperty: 'stuffId',
+    stuffTalentUsersProperty: 'stuffUsers',
     getItemsProperty: 'stuffs',
     insertItemReqDto: 'stuffReqDto',
   },
   {
-    pathName: PathName.TALENT,
+    pageKey: PageKey.TALENT,
     baseApi: `/${apiVer}/talents`,
     toggleLikeApi: `/${apiVer}/talents-users/likes`,
-    toggleLikeIdProperty: 'talentId',
-    likeUsersProperty: 'talentUsers',
+    createChatApi: `/${apiVer}/talents-users/chatrooms`,
+    stuffTalentIdProperty: 'talentId',
+    stuffTalentUsersProperty: 'talentUsers',
     getItemsProperty: 'talents',
     insertItemReqDto: 'talentReqDto',
   },
@@ -82,8 +87,8 @@ export class StuffTalentStore {
 
   readonly predefined: IStuffTalentPredefined
 
-  constructor(pathName: PathName) {
-    this.predefined = predefined.find((p) => p.pathName === pathName) || predefined[0]
+  constructor(pathName: PageKey) {
+    this.predefined = predefined.find((p) => p.pageKey === pathName) || predefined[0]
     this.getCategoriesBy(pathName)
   }
 
@@ -183,11 +188,11 @@ export class StuffTalentStore {
             content: form.content,
             price: form.price,
             exchangeText: form.exchangeText,
-            isExchangable: form.isExchangeable,
+            isExchangeable: form.isExchangeable,
             isNegotiable: form.isNegotiable,
             isPublic: form.isPublic,
             isUse: true,
-          }),
+          } as IStuffTalentInsertReqDto),
         ],
         {
           type: 'application/json',
@@ -217,7 +222,7 @@ export class StuffTalentStore {
   @task.resolved
   toggleLike = (async (id: number, isLike: boolean) => {
     await api.post(this.predefined.toggleLikeApi, {
-      [`${this.predefined.toggleLikeIdProperty}`]: id,
+      [`${this.predefined.stuffTalentIdProperty}`]: id,
       isLike,
       isUse: true,
     })
@@ -282,4 +287,14 @@ export class StuffTalentStore {
   resetUpdateForm() {
     this.updateForm = initState.form
   }
+
+  @task.resolved
+  createChat = (async (payload: ICreateChatDto) => {
+    await api
+      .post(this.predefined.createChatApi, {
+        ...payload,
+        isUse: true,
+      })
+      .catch(({ status }) => console.error('createChat response status:', status))
+  }) as TaskBy<ICreateChatDto>
 }

--- a/src/utils/type-util.ts
+++ b/src/utils/type-util.ts
@@ -1,1 +1,2 @@
 export type ValueOf<T> = T[keyof T]
+export const getKeyValue = <T, K extends keyof T>(obj: T, key: K): T[K] => obj[key]


### PR DESCRIPTION
물건재능 상세보기 화면을 구현했어요.


+ StuffTalentPathName enum 이름을 ...PageKey 로 변경했어요.
+ stuff와 talent 간에 구분되는 값들(api 경로, property명, route함수, store 변수 등)을 기존에는 if문으로 구분해서 판단했는데, (predefined라는 모호한 이름의) 데이터 객체로 추출해 두고 string index를 이용해서 참조하는 식으로 바꿨어요.
나중에 최종적으로는 class를 구분하던지 해야겠어요.

TODO: 거래 채팅방 생성이 되지않는 이슈가 있어서 서버쪽 수정사항이 반영되고 나면 동작확인할 예정이에요. 혹싀 여유있을 때 리뷰 먼저 해주시면, 해당 부분 확인하고 나서 반영요청할게용

ISSUE: 상세보기 페이지에서 수정 페이지로 진입할 때, 콘솔에 다음 에러가 찍혀요.

Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

지금으로선 동작상에 문제가 있어 보이진 않는데, 이야기/물건재능/소모임 모두 동일한 에러가 출력되니 차후에 수정이 필요할 것 같아요.
현재 파악한 원인은, 수정 버튼을 클릭하면 store.getForm 을 호출하는데 그 안에서 getItem 이 호출되면서 store.item객체가 변경돼요. 상세보기 화면이 item객체를 observe하고 있기 때문에 변경사항에 반응해서 렌더링을 시도하게 되는데, 이미 수정화면으로 전환되고 있는 시점이라서 위의 에러 로그가 출력되는 것 같아요.
observe를 중지시킬 수는 없는 것 같더라고요. 어떤 식으로 해결할 수 있을지 좀더 찾아봐야 할 것 같아요.